### PR TITLE
docs: update claude-typer capabilities in READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -22,8 +22,10 @@ Render a Claude Code CLI prompt typing animation video from plain text prompts.
 - Producing prompt-typing visuals that depict text being entered in Claude Code.
 
 **Core capabilities:**
-- Uses a Remotion-based rendering workflow against a remote composition.
-- Runs deterministic frame interpolation suitable for parallel/out-of-order rendering.
+- Calls Remotion CLI to render a remote composition.
+- Outputs transparent-background ProRes 4444 MOV format videos by default.
+- Smartly extracts the core prompt content as the output file name.
+- Supports customizing render parameters like video dimensions, Claude window size, and passing through unknown CLI arguments.
 
 ### svg-assembly-animator
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ npx skills add vibe-motion/skills
 - 产出展示“在 Claude Code 中输入提示词”过程的打字动效。
 
 **核心能力：**
-- 使用基于 Remotion 的渲染流程，对远端 composition 进行渲染。
-- 使用确定性逐帧插值，适配并行/乱序渲染。
+- 调用 Remotion CLI 对远端 composition 进行渲染。
+- 默认输出带有透明背景的 ProRes 4444 MOV 格式视频。
+- 智能提取提示词核心内容作为输出文件名。
+- 支持自定义视频尺寸、Claude 窗口大小等渲染参数，并支持透传未知 CLI 参数。
 
 ### svg-assembly-animator
 


### PR DESCRIPTION
Updated the description of the `claude-typer` skill in both `README.md` and `README.en.md` to match the latest capabilities outlined in `claude-typer/SKILL.md`.

- Updated "Core capabilities" (`核心能力`) bullet points.
- Kept the original GIF and other sections intact.
- Mentions default transparent ProRes 4444 MOV output, smart output file naming based on prompt content, and customizable rendering parameters.

---
*PR created automatically by Jules for task [2476716560137658723](https://jules.google.com/task/2476716560137658723) started by @sxhzju*