### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -153,4 +153,4 @@ TG group: t.me/zjucat
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vibe-motion/skills&type=Date)](https://www.star-history.com/#vibe-motion/skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vibe-motion/skills&type=Date)](https://star-history.dera.page/#vibe-motion/skills&Date)

--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ npx skills add vibe-motion/skills
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vibe-motion/skills&type=Date)](https://www.star-history.com/#vibe-motion/skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vibe-motion/skills&type=Date)](https://star-history.dera.page/#vibe-motion/skills&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This update switches the chart to the star-history.dera.page alternative, which uses a different data source that requires no API token, so the chart displays correctly again.